### PR TITLE
feat!: use the new Data.from() facility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=0.24.0-SNAPSHOT
-kestraVersion=[0.23,)
+kestraVersion=[0.24,)

--- a/src/test/java/io/kestra/plugin/meilisearch/DocumentAddFacetSearchTest.java
+++ b/src/test/java/io/kestra/plugin/meilisearch/DocumentAddFacetSearchTest.java
@@ -5,8 +5,6 @@ import com.meilisearch.sdk.Client;
 import com.meilisearch.sdk.Config;
 import com.meilisearch.sdk.model.Settings;
 import io.kestra.core.junit.annotations.KestraTest;
-import io.kestra.core.models.property.Data;
-import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.FileSerde;
@@ -47,11 +45,10 @@ class DocumentAddFacetSearchTest {
         InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("examples/facetSearchMovies");
 
         URI uri = storageInterface.put(TenantService.MAIN_TENANT, null, URI.create("/" + IdUtils.create() + ".ion"), inputStream);
-        Data<Map> data = Data.<Map>builder().fromURI(Property.of(uri)).build();
 
         RunContext addRunContext = runContextFactory.of(ImmutableMap.of());
 
-        DocumentAdd documentAdd = TestUtils.createDocumentAdd(data, FACET_SEARCH_INDEX);
+        DocumentAdd documentAdd = TestUtils.createDocumentAdd(uri.toString(), FACET_SEARCH_INDEX);
         documentAdd.run(addRunContext);
 
         Thread.sleep(500);

--- a/src/test/java/io/kestra/plugin/meilisearch/DocumentAddGetTest.java
+++ b/src/test/java/io/kestra/plugin/meilisearch/DocumentAddGetTest.java
@@ -2,8 +2,6 @@ package io.kestra.plugin.meilisearch;
 
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.junit.annotations.KestraTest;
-import io.kestra.core.models.property.Data;
-import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.storages.StorageInterface;
@@ -37,10 +35,8 @@ class DocumentAddGetTest {
             "title", "Notebook",
             "genres", new String[]{"Romance","Drama"}
         );
-        Data<Map> data = Data.<Map>builder().fromMap(Property.of(document)).build();
-
         RunContext addRunContext = runContextFactory.of(ImmutableMap.of());
-        DocumentAdd documentAdd = TestUtils.createDocumentAdd(data, index);
+        DocumentAdd documentAdd = TestUtils.createDocumentAdd(document, index);
 
         documentAdd.run(addRunContext);
 
@@ -52,7 +48,7 @@ class DocumentAddGetTest {
 
         DocumentGet.Output getOutput = documentGet.run(getRunContext);
 
-        Map<String, Object> doc = (Map<String, Object>) getOutput.getDocument();
+        Map<String, Object> doc = getOutput.getDocument();
         assertThat(doc.get("id"), is(id));
     }
 
@@ -64,10 +60,9 @@ class DocumentAddGetTest {
         InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("examples/documentAdd");
 
         URI uri = storageInterface.put(TenantService.MAIN_TENANT, null, URI.create("/" + IdUtils.create() + ".ion"), inputStream);
-        Data<Map> data = Data.<Map>builder().fromURI(Property.of(uri)).build();
 
         RunContext addRunContext = runContextFactory.of(ImmutableMap.of());
-        DocumentAdd documentAdd = TestUtils.createDocumentAdd(data, index);
+        DocumentAdd documentAdd = TestUtils.createDocumentAdd(uri.toString(), index);
 
         documentAdd.run(addRunContext);
 
@@ -79,7 +74,7 @@ class DocumentAddGetTest {
 
         DocumentGet.Output getOutput = documentGet.run(getRunContext);
 
-        Map<String, Object> doc = (Map<String, Object>) getOutput.getDocument();
+        Map<String, Object> doc = getOutput.getDocument();
         assertThat(doc.get("id"), is(id));
         assertThat(doc.get("name"), is("Bryan"));
     }

--- a/src/test/java/io/kestra/plugin/meilisearch/DocumentAddSearchTest.java
+++ b/src/test/java/io/kestra/plugin/meilisearch/DocumentAddSearchTest.java
@@ -2,8 +2,6 @@ package io.kestra.plugin.meilisearch;
 
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.junit.annotations.KestraTest;
-import io.kestra.core.models.property.Data;
-import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.FileSerde;
@@ -40,11 +38,10 @@ class DocumentAddSearchTest {
 
         InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("examples/basicSearchName");
         URI uri = storageInterface.put(TenantService.MAIN_TENANT, null, URI.create("/" + IdUtils.create() + ".ion"), inputStream);
-        Data<Map> data = Data.<Map>builder().fromURI(Property.of(uri)).build();
 
         RunContext addRunContext = runContextFactory.of(ImmutableMap.of());
 
-        DocumentAdd documentAdd = TestUtils.createDocumentAdd(data, SEARCH_INDEX);
+        DocumentAdd documentAdd = TestUtils.createDocumentAdd(uri.toString(), SEARCH_INDEX);
 
         documentAdd.run(addRunContext);
 

--- a/src/test/java/io/kestra/plugin/meilisearch/TestUtils.java
+++ b/src/test/java/io/kestra/plugin/meilisearch/TestUtils.java
@@ -1,10 +1,8 @@
 package io.kestra.plugin.meilisearch;
 
-import io.kestra.core.models.property.Data;
 import io.kestra.core.models.property.Property;
 
 import java.util.List;
-import java.util.Map;
 
 public class TestUtils {
 
@@ -12,10 +10,10 @@ public class TestUtils {
     public static final Property<String> URL = Property.of("http://localhost:7700");
     public static final Property<String> MASTER_KEY = Property.of("MASTER_KEY");
 
-    public static DocumentAdd createDocumentAdd(Data<Map> data, String index) {
+    public static DocumentAdd createDocumentAdd(Object from, String index) {
         return DocumentAdd.builder()
-            .data(data)
-            .index(Property.of(index))
+            .from(from)
+            .index(Property.ofValue(index))
             .url(URL)
             .key(MASTER_KEY)
             .build();
@@ -23,8 +21,8 @@ public class TestUtils {
 
     public static DocumentGet createDocumentGet(String id, String index) {
         return DocumentGet.builder()
-            .documentId(Property.of(id))
-            .index(Property.of(index))
+            .documentId(Property.ofValue(id))
+            .index(Property.ofValue(index))
             .url(URL)
             .key(MASTER_KEY)
             .build();
@@ -32,8 +30,8 @@ public class TestUtils {
 
     public static Search createSearch(String pattern, String index) {
         return Search.builder()
-            .query(Property.of(pattern))
-            .index(Property.of(index))
+            .query(Property.ofValue(pattern))
+            .index(Property.ofValue(index))
             .url(URL)
             .key(MASTER_KEY)
             .build();
@@ -41,10 +39,10 @@ public class TestUtils {
 
     public static FacetSearch createFacetSearch(String facetName, String facetQuery, List<String> filters, String index) {
         return FacetSearch.builder()
-            .facetName(Property.of(facetName))
-            .facetQuery(Property.of(facetQuery))
-            .filters(Property.of(filters))
-            .index(Property.of(index))
+            .facetName(Property.ofValue(facetName))
+            .facetQuery(Property.ofValue(facetQuery))
+            .filters(Property.ofValue(filters))
+            .index(Property.ofValue(index))
             .url(URL)
             .key(MASTER_KEY)
             .build();


### PR DESCRIPTION
## Breaking change

The `DocumentAdd` task now use a `from` attribute to pass content to add to the database.
This has been done to align this task with all the existing tasks that support this same mechanism.