### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/meilisearch/DocumentAdd.java
+++ b/src/main/java/io/kestra/plugin/meilisearch/DocumentAdd.java
@@ -25,6 +25,7 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -79,10 +80,12 @@ public class DocumentAdd extends AbstractMeilisearchConnection implements Runnab
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @NotNull
+    @PluginProperty(group = "main")
     private Object from;
 
     @NotNull
     @Schema(title = "Index", description = "Name of the Meilisearch index to add documents to.")
+    @PluginProperty(group = "main")
     private Property<String> index;
 
     @Override

--- a/src/main/java/io/kestra/plugin/meilisearch/DocumentGet.java
+++ b/src/main/java/io/kestra/plugin/meilisearch/DocumentGet.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -54,10 +55,12 @@ import lombok.experimental.SuperBuilder;
 public class DocumentGet extends AbstractMeilisearchConnection implements RunnableTask<DocumentGet.Output> {
     @NotNull
     @Schema(title = "Document ID", description = "Identifier of the document to retrieve; templated before the request.")
+    @PluginProperty(group = "main")
     private Property<String> documentId;
 
     @NotNull
     @Schema(title = "Index", description = "Name of the Meilisearch index containing the document.")
+    @PluginProperty(group = "main")
     private Property<String> index;
 
     @Override

--- a/src/main/java/io/kestra/plugin/meilisearch/FacetSearch.java
+++ b/src/main/java/io/kestra/plugin/meilisearch/FacetSearch.java
@@ -20,6 +20,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -71,17 +72,21 @@ public class FacetSearch extends AbstractMeilisearchConnection implements Runnab
 
     @Schema(title = "Index", description = "Name of the Meilisearch index to search.")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> index;
 
     @Schema(title = "Facet name", description = "Facet attribute configured as filterable (e.g., facetName \"genre\" on a film index).")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> facetName;
 
     @Schema(title = "Facet query", description = "Query string applied to the specified facet; optional.")
+    @PluginProperty(group = "advanced")
     private Property<String> facetQuery;
 
     @Schema(title = "Filters", description = "List of Meilisearch filters applied to the facet search; defaults to an empty list.")
     @Builder.Default
+    @PluginProperty(group = "processing")
     private Property<List<String>> filters = Property.ofValue(new ArrayList<>());
 
     @Override

--- a/src/main/java/io/kestra/plugin/meilisearch/MeilisearchConnectionInterface.java
+++ b/src/main/java/io/kestra/plugin/meilisearch/MeilisearchConnectionInterface.java
@@ -4,17 +4,20 @@ import io.kestra.core.models.property.Property;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import io.kestra.core.models.annotations.PluginProperty;
 
 public interface MeilisearchConnectionInterface {
     @NotNull
     @Schema(
         title = "Meilisearch connection URL"
     )
+    @PluginProperty(group = "main")
     Property<String> getUrl();
 
     @NotNull
     @Schema(
         title = "Meilisearch connection key"
     )
+    @PluginProperty(group = "main")
     Property<String> getKey();
 }

--- a/src/main/java/io/kestra/plugin/meilisearch/Search.java
+++ b/src/main/java/io/kestra/plugin/meilisearch/Search.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -61,8 +62,10 @@ import reactor.core.publisher.Flux;
 public class Search extends AbstractMeilisearchConnection implements RunnableTask<Search.Output> {
 
     @Schema(title = "Search query", description = "Full-text query string sent to Meilisearch; templated before execution.")
+    @PluginProperty(group = "main")
     private Property<String> query;
     @Schema(title = "Index", description = "Name of the Meilisearch index to search.")
+    @PluginProperty(group = "advanced")
     private Property<String> index;
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712