### PR TITLE
feat(DocumentAdd): batch documents and wait for indexing tasks

### DIFF
--- a/src/main/java/io/kestra/plugin/meilisearch/DocumentAdd.java
+++ b/src/main/java/io/kestra/plugin/meilisearch/DocumentAdd.java
@@ -1,10 +1,16 @@
 package io.kestra.plugin.meilisearch;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.slf4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meilisearch.sdk.Client;
 import com.meilisearch.sdk.Index;
+import com.meilisearch.sdk.model.TaskError;
+import com.meilisearch.sdk.model.TaskStatus;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
@@ -13,11 +19,11 @@ import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Data;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
-import io.kestra.core.models.tasks.VoidOutput;
 import io.kestra.core.runners.RunContext;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,7 +40,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @NoArgsConstructor
 @Schema(
     title = "Add documents to Meilisearch",
-    description = "Adds one or multiple documents to a Meilisearch index using the [add-or-replace API](https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents). Documents are read from the `from` source, rendered by Kestra, and sent with Meilisearch defaults for primary key handling; requires index URL and API key."
+    description = "Adds one or multiple documents to a Meilisearch index using the [add-or-replace API](https://www.meilisearch.com/docs/reference/api/documents#add-or-replace-documents). Documents are read from the `from` source, rendered by Kestra, and sent in batches; by default the task waits for the indexing tasks to complete and fails if any of them fails. Requires index URL and API key."
 )
 @Plugin(
     examples = {
@@ -76,8 +82,11 @@ import io.kestra.core.models.annotations.PluginProperty;
         )
     }
 )
-public class DocumentAdd extends AbstractMeilisearchConnection implements RunnableTask<VoidOutput>, Data.From {
+public class DocumentAdd extends AbstractMeilisearchConnection implements RunnableTask<DocumentAdd.Output>, Data.From {
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final int DEFAULT_BATCH_SIZE = 1000;
+    private static final Duration DEFAULT_WAIT_TIMEOUT = Duration.ofMinutes(5);
+    private static final int WAIT_INTERVAL_MS = 500;
 
     @NotNull
     @PluginProperty(group = "main")
@@ -88,27 +97,75 @@ public class DocumentAdd extends AbstractMeilisearchConnection implements Runnab
     @PluginProperty(group = "main")
     private Property<String> index;
 
+    @Schema(title = "Batch size", description = "Number of documents sent to Meilisearch per request; each batch is enqueued as one indexing task.")
+    @Builder.Default
+    @PluginProperty(group = "advanced")
+    private Property<Integer> batchSize = Property.ofValue(DEFAULT_BATCH_SIZE);
+
+    @Schema(title = "Wait for indexing", description = "Whether to wait for the enqueued indexing tasks to complete; the run fails if a task fails. Disable for fire-and-forget behavior.")
+    @Builder.Default
+    @PluginProperty(group = "advanced")
+    private Property<Boolean> waitForIndexing = Property.ofValue(true);
+
+    @Schema(title = "Wait timeout", description = "Maximum time to wait for each indexing task when `waitForIndexing` is enabled.")
+    @Builder.Default
+    @PluginProperty(group = "advanced")
+    private Property<Duration> waitTimeout = Property.ofValue(DEFAULT_WAIT_TIMEOUT);
+
     @Override
-    public VoidOutput run(RunContext runContext) throws Exception {
+    public Output run(RunContext runContext) throws Exception {
         Logger logger = runContext.logger();
 
         Client client = this.createClient(runContext);
         var renderedIndex = runContext.render(this.index).as(String.class).orElseThrow();
         Index documentIndex = client.index(renderedIndex);
+        var renderedBatchSize = runContext.render(this.batchSize).as(Integer.class).orElse(DEFAULT_BATCH_SIZE);
 
+        List<Integer> taskUids = new ArrayList<>();
         Integer count = Data.from(from).read(runContext)
-            .map(throwFunction(row ->
+            .buffer(renderedBatchSize)
+            .map(throwFunction(batch ->
             {
-                documentIndex.addDocuments(MAPPER.writeValueAsString(row));
-                return 1;
+                taskUids.add(documentIndex.addDocuments(MAPPER.writeValueAsString(batch)).getTaskUid());
+                return batch.size();
             }))
             .reduce(Integer::sum)
             .blockOptional()
             .orElse(0);
 
-        runContext.metric(Counter.of("documentAdded", count));
-        logger.info("Successfully added documents to index {}", renderedIndex);
+        if (runContext.render(this.waitForIndexing).as(Boolean.class).orElse(true)) {
+            int timeoutMs = (int) runContext.render(this.waitTimeout).as(Duration.class).orElse(DEFAULT_WAIT_TIMEOUT).toMillis();
+            for (Integer taskUid : taskUids) {
+                documentIndex.waitForTask(taskUid, timeoutMs, WAIT_INTERVAL_MS);
+                var task = documentIndex.getTask(taskUid);
+                if (TaskStatus.FAILED.equals(task.getStatus()) || TaskStatus.CANCELED.equals(task.getStatus())) {
+                    TaskError error = task.getError();
+                    throw new RuntimeException(String.format(
+                        "Meilisearch indexing task %d on index '%s' ended with status %s%s",
+                        taskUid,
+                        renderedIndex,
+                        task.getStatus(),
+                        error != null ? ": " + error.getMessage() + " (" + error.getCode() + ")" : ""
+                    ));
+                }
+            }
+        }
 
-        return null;
+        runContext.metric(Counter.of("documentAdded", count));
+        logger.info("Successfully added {} documents to index {} in {} batches", count, renderedIndex, taskUids.size());
+
+        return Output.builder()
+            .taskUids(taskUids)
+            .documentsAdded(count)
+            .build();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "Task UIDs", description = "UIDs of the Meilisearch indexing tasks enqueued for the added documents, one per batch.")
+        private final List<Integer> taskUids;
+        @Schema(title = "Documents added", description = "Number of documents sent to Meilisearch.")
+        private final Integer documentsAdded;
     }
 }

--- a/src/test/java/io/kestra/plugin/meilisearch/DocumentAddFacetSearchTest.java
+++ b/src/test/java/io/kestra/plugin/meilisearch/DocumentAddFacetSearchTest.java
@@ -54,8 +54,6 @@ class DocumentAddFacetSearchTest {
         DocumentAdd documentAdd = TestUtils.createDocumentAdd(uri.toString(), FACET_SEARCH_INDEX);
         documentAdd.run(addRunContext);
 
-        Thread.sleep(500);
-
         RunContext facetSearchRunContext = runContextFactory.of(ImmutableMap.of());
         FacetSearch facetSearch = TestUtils.createFacetSearch(facetName, facetQuery, filters, FACET_SEARCH_INDEX);
         FacetSearch.Output facetSearchOutput = facetSearch.run(facetSearchRunContext);

--- a/src/test/java/io/kestra/plugin/meilisearch/DocumentAddGetTest.java
+++ b/src/test/java/io/kestra/plugin/meilisearch/DocumentAddGetTest.java
@@ -43,8 +43,6 @@ class DocumentAddGetTest {
 
         documentAdd.run(addRunContext);
 
-        Thread.sleep(500);
-
         RunContext getRunContext = runContextFactory.of(ImmutableMap.of());
 
         DocumentGet documentGet = TestUtils.createDocumentGet(id, index);
@@ -68,8 +66,6 @@ class DocumentAddGetTest {
         DocumentAdd documentAdd = TestUtils.createDocumentAdd(uri.toString(), index);
 
         documentAdd.run(addRunContext);
-
-        Thread.sleep(500);
 
         RunContext getRunContext = runContextFactory.of(ImmutableMap.of());
 

--- a/src/test/java/io/kestra/plugin/meilisearch/DocumentAddSearchTest.java
+++ b/src/test/java/io/kestra/plugin/meilisearch/DocumentAddSearchTest.java
@@ -48,8 +48,6 @@ class DocumentAddSearchTest {
 
         documentAdd.run(addRunContext);
 
-        Thread.sleep(500);
-
         RunContext searchRunContext = runContextFactory.of(ImmutableMap.of());
 
         Search search = TestUtils.createSearch(pattern, SEARCH_INDEX);

--- a/src/test/java/io/kestra/plugin/meilisearch/DocumentAddTest.java
+++ b/src/test/java/io/kestra/plugin/meilisearch/DocumentAddTest.java
@@ -1,0 +1,86 @@
+package io.kestra.plugin.meilisearch;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.tenant.TenantService;
+import io.kestra.core.utils.IdUtils;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KestraTest
+class DocumentAddTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private StorageInterface storageInterface;
+
+    @Test
+    void testDocumentAddBatchesDocuments() throws Exception {
+        String index = "testBatch" + IdUtils.create();
+        String documents = IntStream.rangeClosed(1, 10)
+            .mapToObj(i -> "{\"id\": \"" + i + "\",\"name\": \"Person" + i + "\"}")
+            .collect(Collectors.joining("\n"));
+        URI uri = storageInterface.put(
+            TenantService.MAIN_TENANT,
+            null,
+            URI.create("/" + IdUtils.create() + ".ion"),
+            new ByteArrayInputStream(documents.getBytes(StandardCharsets.UTF_8))
+        );
+
+        DocumentAdd documentAdd = DocumentAdd.builder()
+            .from(uri.toString())
+            .index(Property.ofValue(index))
+            .batchSize(Property.ofValue(4))
+            .url(TestUtils.URL)
+            .key(TestUtils.MASTER_KEY)
+            .build();
+
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+        DocumentAdd.Output output = documentAdd.run(runContext);
+
+        assertThat(output.getTaskUids(), hasSize(3));
+        assertThat(output.getDocumentsAdded(), is(10));
+
+        DocumentGet documentGet = TestUtils.createDocumentGet("7", index);
+        Map<String, Object> document = documentGet.run(runContextFactory.of(ImmutableMap.of())).getDocument();
+        assertThat(document.get("name"), is("Person7"));
+    }
+
+    @Test
+    void testDocumentAddFailsWhenIndexingTaskFails() throws Exception {
+        String index = "testFailure" + IdUtils.create();
+        String documents = "{\"name\": \"NoPrimaryKeyCandidate\"}";
+        URI uri = storageInterface.put(
+            TenantService.MAIN_TENANT,
+            null,
+            URI.create("/" + IdUtils.create() + ".ion"),
+            new ByteArrayInputStream(documents.getBytes(StandardCharsets.UTF_8))
+        );
+
+        DocumentAdd documentAdd = TestUtils.createDocumentAdd(uri.toString(), index);
+
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+        Exception exception = assertThrows(Exception.class, () -> documentAdd.run(runContext));
+
+        assertThat(exception.getMessage(), containsString("primary key"));
+    }
+}


### PR DESCRIPTION
## What

Two improvements to `DocumentAdd`:

1. **Batched ingestion** — documents from `from` are now sent in configurable batches (new `batchSize` property, default 1000) instead of one HTTP request and one Meilisearch task per document. Large ingestions go from N requests to ceil(N/batchSize).

2. **Indexing verification** — Meilisearch document addition is asynchronous: the HTTP call succeeding only means the task was enqueued. Previously a failed indexing task (e.g. primary key inference failure) still reported success. The task now waits for each enqueued indexing task by default (new `waitForIndexing` property, default `true`, with `waitTimeout`, default 5 minutes) and fails the run with the Meilisearch task error message and code when a task ends `failed` or `canceled`.

The task also returns an output now (`taskUids` — one per batch — and `documentsAdded`) instead of `VoidOutput`, so downstream tasks can reference the enqueued tasks, notably when `waitForIndexing: false`.

## Tests

- New `DocumentAddTest` covering both behaviors: 10 documents with `batchSize: 4` produce exactly 3 indexing tasks and are immediately retrievable; a document without an inferable primary key fails the run with the task error.
- Removed the four `Thread.sleep(500)` calls in existing tests — they were racing against async indexing, which the task now waits for.
- Full suite passes (9 tests) against a local Meilisearch from `docker-compose-ci.yml`.

Closes https://github.com/kestra-io/plugin-meilisearch/issues/8 